### PR TITLE
Feat/401처리및재로그인흐름/#55/junsoo

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,6 +12,7 @@ import LockerDetailView from '@/views/LockerDetailView.vue'
 import EventDetailView from '@/views/EventDetailView.vue'
 import { clearAiSheetSession, isAiDetailPath } from '@/utils/aiSheetSession'
 import { useAuthStore } from '@/stores/useAuthStore'
+import { buildLoginLocation } from '@/utils/authFlow'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -36,12 +37,17 @@ router.beforeEach(async (to) => {
   const requiresAuth = ['discover', 'ai', 'result', 'map', 'saved', 'profile', 'profile-setup'].includes(String(to.name || ''))
 
   if (requiresAuth && !authStore.isAuthenticated) {
-    return { name: 'landing' }
+    return buildLoginLocation(to.fullPath)
   }
   if (!authStore.isAuthenticated) return true
 
   if (!authStore.user) {
-    await authStore.loadMe().catch(() => null)
+    try {
+      await authStore.loadMe()
+    } catch {
+      authStore.clearSession()
+      return buildLoginLocation(to.fullPath, {expired: true})
+    }
   }
   const hasNickname = !!(authStore.user?.nickname && String(authStore.user.nickname).trim())
   const hasPersona = !!(authStore.user?.localPreference && String(authStore.user.localPreference).trim())

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,3 +1,5 @@
+import { createAuthExpiredError } from "@/utils/authFlow"
+
 const isBrowser = typeof window !== 'undefined'
 
 function isLocalFrontendHost() {
@@ -79,6 +81,7 @@ export async function fetchMe(accessToken) {
     },
   })
   const data = await parseJson(res)
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(data.message || '내 정보 조회에 실패했습니다.')
   return data
 }
@@ -93,6 +96,7 @@ export async function updateMyNickname(accessToken, nickname) {
     body: JSON.stringify({ nickname }),
   })
   const data = await parseJson(res)
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(data.message || '닉네임 저장에 실패했습니다.')
   return data
 }
@@ -107,6 +111,7 @@ export async function updateMyProfile(accessToken, { nickname, localPreference, 
     body: JSON.stringify({ nickname, localPreference, preferredLanguage }),
   })
   const data = await parseJson(res)
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(data.message || '프로필 저장에 실패했습니다.')
   return data
 }

--- a/src/services/savedAttractionsService.js
+++ b/src/services/savedAttractionsService.js
@@ -1,3 +1,5 @@
+import { createAuthExpiredError } from "@/utils/authFlow"
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 function authHeaders(accessToken) {
@@ -17,7 +19,7 @@ export async function fetchSavedAttractions(accessToken) {
   const res = await fetch(`${BASE_URL}/api/v1/me/saved/attractions`, {
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(`저장 관광지 목록 조회 실패: ${res.status}`)
   return res.json()
 }
@@ -34,7 +36,7 @@ export async function toggleSavedAttraction(attractionId, accessToken) {
     method: 'POST',
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) {
     let msg = `저장 처리 실패: ${res.status}`
     try {

--- a/src/services/savedEventsService.js
+++ b/src/services/savedEventsService.js
@@ -1,3 +1,5 @@
+import { createAuthExpiredError } from "@/utils/authFlow"
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 function authHeaders(accessToken) {
@@ -17,7 +19,7 @@ export async function fetchSavedEvents(accessToken) {
   const res = await fetch(`${BASE_URL}/api/v1/me/saved/events`, {
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(`저장 행사 목록 조회 실패: ${res.status}`)
   return res.json()
 }
@@ -34,7 +36,7 @@ export async function toggleSavedEvent(contentId, accessToken) {
     method: 'POST',
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) {
     let msg = `행사 저장 처리 실패: ${res.status}`
     try {

--- a/src/services/savedPlansService.js
+++ b/src/services/savedPlansService.js
@@ -1,3 +1,5 @@
+import { createAuthExpiredError } from "@/utils/authFlow"
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 function authHeaders(accessToken) {
@@ -44,7 +46,7 @@ export async function fetchSavedPlans(accessToken) {
   const res = await fetch(`${BASE_URL}/api/v1/me/saved/plans`, {
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(`저장 일정 목록 조회 실패: ${res.status}`)
   return res.json()
 }
@@ -59,7 +61,7 @@ export async function fetchSavedPlanDetail(planId, accessToken) {
   const res = await fetch(`${BASE_URL}/api/v1/me/saved/plans/${planId}`, {
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (res.status === 404) throw new Error('저장된 일정을 찾을 수 없습니다.')
   if (!res.ok) throw new Error(`일정 상세 조회 실패: ${res.status}`)
   return res.json()
@@ -83,7 +85,7 @@ export async function saveStructuredPlan(accessToken, body) {
       structured: plain,
     }),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) {
     let msg = `일정 저장 실패: ${res.status}`
     try {

--- a/src/services/tourCourseService.js
+++ b/src/services/tourCourseService.js
@@ -1,3 +1,5 @@
+import { createAuthExpiredError } from "@/utils/authFlow"
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 function authHeaders(accessToken) {
@@ -32,7 +34,7 @@ export async function fetchSavedTourCourses(lang = 'KOR', accessToken) {
   const res = await fetch(`${BASE_URL}/api/v1/courses/saved?${q}`, {
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) throw new Error(`저장 코스 목록 조회 실패: ${res.status}`)
   const data = await res.json()
   return Array.isArray(data) ? data.map(normalizeCourseSummary) : []
@@ -50,7 +52,7 @@ export async function toggleTourCourseSave(courseId, accessToken) {
     method: 'POST',
     headers: authHeaders(accessToken),
   })
-  if (res.status === 401) throw new Error('로그인이 만료되었습니다.')
+  if (res.status === 401) throw createAuthExpiredError()
   if (!res.ok) {
     let msg = `코스 저장 처리 실패: ${res.status}`
     try {

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -1,19 +1,26 @@
-import { computed, ref } from 'vue'
-import { defineStore } from 'pinia'
-import { fetchMe, loginWithEmail, signupWithEmail, updateMyNickname, updateMyProfile } from '@/services/authService'
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+import {
+  fetchMe,
+  loginWithEmail,
+  signupWithEmail,
+  updateMyNickname,
+  updateMyProfile,
+} from '@/services/authService';
+import { buildLoginLocation } from '@/utils/authFlow';
 
-const STORAGE_KEY = 'bts:auth:v1'
+const STORAGE_KEY = 'bts:auth:v1';
 
 export const useAuthStore = defineStore('auth', () => {
-  const accessToken = ref('')
-  const refreshToken = ref('')
-  const tokenType = ref('Bearer')
-  const expiresIn = ref(0)
-  const user = ref(null)
-  const isLoading = ref(false)
-  const error = ref('')
+  const accessToken = ref('');
+  const refreshToken = ref('');
+  const tokenType = ref('Bearer');
+  const expiresIn = ref(0);
+  const user = ref(null);
+  const isLoading = ref(false);
+  const error = ref('');
 
-  const isAuthenticated = computed(() => Boolean(accessToken.value))
+  const isAuthenticated = computed(() => Boolean(accessToken.value));
 
   function persist() {
     localStorage.setItem(
@@ -25,106 +32,129 @@ export const useAuthStore = defineStore('auth', () => {
         expiresIn: expiresIn.value,
         user: user.value,
       }),
-    )
+    );
   }
 
   function hydrate() {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
     try {
-      const parsed = JSON.parse(raw)
-      accessToken.value = parsed.accessToken || ''
-      refreshToken.value = parsed.refreshToken || ''
-      tokenType.value = parsed.tokenType || 'Bearer'
-      expiresIn.value = Number(parsed.expiresIn || 0)
-      user.value = parsed.user || null
+      const parsed = JSON.parse(raw);
+      accessToken.value = parsed.accessToken || '';
+      refreshToken.value = parsed.refreshToken || '';
+      tokenType.value = parsed.tokenType || 'Bearer';
+      expiresIn.value = Number(parsed.expiresIn || 0);
+      user.value = parsed.user || null;
     } catch {
-      clearSession()
+      clearSession();
     }
   }
 
   function setSession(payload) {
-    accessToken.value = payload.accessToken || ''
-    refreshToken.value = payload.refreshToken || ''
-    tokenType.value = payload.tokenType || 'Bearer'
-    expiresIn.value = Number(payload.expiresIn || 0)
+    accessToken.value = payload.accessToken || '';
+    refreshToken.value = payload.refreshToken || '';
+    tokenType.value = payload.tokenType || 'Bearer';
+    expiresIn.value = Number(payload.expiresIn || 0);
 
-    const nextUserId = payload.userId || user.value?.userId || ''
-    const nextEmail = payload.email || user.value?.email || ''
-    user.value = nextUserId || nextEmail
-      ? {
-          ...(user.value || {}),
-          userId: nextUserId,
-          email: nextEmail,
-        }
-      : user.value
+    const nextUserId = payload.userId || user.value?.userId || '';
+    const nextEmail = payload.email || user.value?.email || '';
+    user.value =
+      nextUserId || nextEmail
+        ? {
+            ...(user.value || {}),
+            userId: nextUserId,
+            email: nextEmail,
+          }
+        : user.value;
 
-    persist()
+    persist();
   }
 
   function clearSession() {
-    accessToken.value = ''
-    refreshToken.value = ''
-    tokenType.value = 'Bearer'
-    expiresIn.value = 0
-    user.value = null
-    error.value = ''
-    localStorage.removeItem(STORAGE_KEY)
+    accessToken.value = '';
+    refreshToken.value = '';
+    tokenType.value = 'Bearer';
+    expiresIn.value = 0;
+    user.value = null;
+    error.value = '';
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  async function tryRestoreSession() {
+    // 아직 refresh token API가 확실하지 않아서
+    // 지금 단계에서는 복구 불가로 처리
+    return false;
+  }
+
+  async function handleAuthExpired(router, route) {
+    const restored = await tryRestoreSession();
+    if (restored) return true;
+
+    clearSession();
+
+    await router.replace(
+      buildLoginLocation(route?.fullPath || '/discover', { expired: true }),
+    );
+    return false;
   }
 
   async function login(email, password) {
-    isLoading.value = true
-    error.value = ''
+    isLoading.value = true;
+    error.value = '';
     try {
-      const data = await loginWithEmail({ email, password })
-      setSession(data)
-      return data
+      const data = await loginWithEmail({ email, password });
+      setSession(data);
+      return data;
     } catch (e) {
-      error.value = e.message || '로그인 실패'
-      throw e
+      error.value = e.message || '로그인 실패';
+      throw e;
     } finally {
-      isLoading.value = false
+      isLoading.value = false;
     }
   }
 
   async function signup(email, password) {
-    isLoading.value = true
-    error.value = ''
+    isLoading.value = true;
+    error.value = '';
     try {
-      const data = await signupWithEmail({ email, password })
+      const data = await signupWithEmail({ email, password });
       // 백엔드가 가입 직후 토큰을 반환하면 바로 세션 저장
-      if (data?.accessToken) setSession(data)
-      return data
+      if (data?.accessToken) setSession(data);
+      return data;
     } catch (e) {
-      error.value = e.message || '회원가입 실패'
-      throw e
+      error.value = e.message || '회원가입 실패';
+      throw e;
     } finally {
-      isLoading.value = false
+      isLoading.value = false;
     }
   }
 
   async function loadMe() {
-    if (!accessToken.value) return null
-    const me = await fetchMe(accessToken.value)
-    user.value = me
-    persist()
-    return me
+    if (!accessToken.value) return null;
+    const me = await fetchMe(accessToken.value);
+    user.value = me;
+    persist();
+    return me;
   }
 
   async function saveNickname(nickname) {
-    if (!accessToken.value) throw new Error('로그인이 필요합니다.')
-    const me = await updateMyNickname(accessToken.value, nickname)
-    user.value = me
-    persist()
-    return me
+    if (!accessToken.value) throw new Error('로그인이 필요합니다.');
+    const me = await updateMyNickname(accessToken.value, nickname);
+    user.value = me;
+    persist();
+    return me;
   }
 
   async function saveProfile({ nickname, localPreference, preferredLanguage }) {
-    if (!accessToken.value) throw new Error('로그인이 필요합니다.')
-    const me = await updateMyProfile(accessToken.value, { nickname, localPreference, preferredLanguage })
-    user.value = me
-    persist()
-    return me
+    if (!accessToken.value) throw new Error('로그인이 필요합니다.');
+    const me = await updateMyProfile(accessToken.value, {
+      nickname,
+      localPreference,
+      preferredLanguage,
+    });
+    user.value = me;
+    persist();
+    return me;
   }
 
   return {
@@ -139,11 +169,12 @@ export const useAuthStore = defineStore('auth', () => {
     hydrate,
     setSession,
     clearSession,
+    tryRestoreSession,
+    handleAuthExpired,
     login,
     signup,
     loadMe,
     saveNickname,
     saveProfile,
-  }
-})
-
+  };
+});

--- a/src/stores/useServerSavedAttractionsStore.js
+++ b/src/stores/useServerSavedAttractionsStore.js
@@ -25,8 +25,9 @@ export const useServerSavedAttractionsStore = defineStore('serverSavedAttraction
     loading.value = true
     try {
       items.value = await fetchSavedAttractions(accessToken)
-    } catch {
+    } catch (e) {
       items.value = []
+      throw e
     } finally {
       loading.value = false
     }

--- a/src/stores/useServerSavedEventsStore.js
+++ b/src/stores/useServerSavedEventsStore.js
@@ -22,8 +22,9 @@ export const useServerSavedEventsStore = defineStore('serverSavedEvents', () => 
     loading.value = true
     try {
       items.value = await fetchSavedEvents(accessToken)
-    } catch {
+    } catch (e) {
       items.value = []
+      throw e
     } finally {
       loading.value = false
     }

--- a/src/utils/authFlow.js
+++ b/src/utils/authFlow.js
@@ -1,0 +1,64 @@
+export const AUTH_EXPIRED_REASON = 'expired';
+export const AUTH_EXPIRED_MESSAGE =
+  '로그인이 만료되었습니다. 다시 로그인해 주세요.';
+
+export function createAuthExpiredError(message = AUTH_EXPIRED_MESSAGE) {
+  const error = new Error(message);
+  error.name = 'AuthExpiredError';
+  error.code = 'AUTH_EXPIRED';
+  return error;
+}
+
+export function isAuthExpiredError(error) {
+  return (
+    error?.code === 'AUTH_EXPIRED' ||
+    error?.name === 'AuthExpiredError' ||
+    error?.message === '로그인이 만료되었습니다.' ||
+    error?.message === AUTH_EXPIRED_MESSAGE
+  );
+}
+
+export function buildLoginLocation(
+  fullPath = '/discover',
+  { expired = false } = {},
+) {
+  const query = {};
+
+  if (fullPath) {
+    query.redirect = fullPath;
+  }
+
+  if (expired) {
+    query.reason = AUTH_EXPIRED_REASON;
+  }
+
+  return {
+    name: 'landing',
+    query,
+  };
+}
+
+export function resolvePostLoginRedirect(route, fallback = '/discover') {
+  const redirect = route?.query?.redirect;
+
+  if (typeof redirect === 'string' && redirect.startsWith('/')) {
+    return redirect;
+  }
+  return fallback;
+}
+
+const POST_LOGIN_REDIRECT_KEY = 'bts:post-login-redirect';
+
+export function storePostLoginRedirect(path) {
+  if (typeof window === 'undefined') return;
+  if (typeof path === 'string' && path.startsWith('/')) {
+    window.sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, path);
+  }
+}
+
+export function consumePostLoginRedirect() {
+  if (typeof window === 'undefined') return '';
+  const saved = window.sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY) || '';
+  window.sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+  return saved;
+}

--- a/src/views/AttractionDetailView.vue
+++ b/src/views/AttractionDetailView.vue
@@ -18,6 +18,7 @@ import {
   ChevronRight,
 } from 'lucide-vue-next'
 import { fetchAttractionById } from '@/services/attractionService'
+import { isAuthExpiredError } from '@/utils/authFlow'
 
 const { t } = useI18n()
 
@@ -59,6 +60,10 @@ watch(
         isLiked.value = serverAttractions.isSaved(id)
       }
     } catch (e) {
+      if (isAuthExpiredError(e)) {
+        await authStore.handleAuthExpired(router, route)
+        return
+      }
       error.value = e.message
     } finally {
       loading.value = false
@@ -73,8 +78,15 @@ watch(
     const id = resolvedId.value
     if (!id || !attraction.value) return
     if (token) {
-      await serverAttractions.refresh(token)
-      isLiked.value = serverAttractions.isSaved(id)
+      try {
+        await serverAttractions.refresh(token)
+        isLiked.value = serverAttractions.isSaved(id)
+      } catch (e) {
+        if (isAuthExpiredError(e)) {
+          await authStore.handleAuthExpired(router, route)
+          return
+        }
+      }
     } else {
       isLiked.value = false
     }
@@ -142,6 +154,10 @@ async function toggleLike() {
     const saved = await serverAttractions.toggle(id, authStore.accessToken)
     isLiked.value = saved
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+        await authStore.handleAuthExpired(router, route)
+        return
+    }
     window.alert?.(e?.message || '저장 처리에 실패했습니다.')
   } finally {
     likeSaving.value = false

--- a/src/views/AuthCallbackView.vue
+++ b/src/views/AuthCallbackView.vue
@@ -1,24 +1,29 @@
 <script setup>
-import { onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { useI18n } from 'vue-i18n'
-import { useAuthStore } from '@/stores/useAuthStore'
+import { onMounted, ref } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useAuthStore } from '@/stores/useAuthStore';
+import {
+  resolvePostLoginRedirect,
+  consumePostLoginRedirect,
+} from '@/utils/authFlow';
 
-const { t } = useI18n()
-const router = useRouter()
-const authStore = useAuthStore()
-const status = ref('')
+const { t } = useI18n();
+const router = useRouter();
+const route = useRoute();
+const authStore = useAuthStore();
+const status = ref('');
 
 onMounted(() => {
-  status.value = t('auth.checking')
-})
+  status.value = t('auth.checking');
+});
 
 function readFromUrl() {
-  const url = new URL(window.location.href)
-  const query = url.searchParams
-  const hash = new URLSearchParams(url.hash.replace(/^#/, ''))
+  const url = new URL(window.location.href);
+  const query = url.searchParams;
+  const hash = new URLSearchParams(url.hash.replace(/^#/, ''));
 
-  const pick = (key) => query.get(key) || hash.get(key) || ''
+  const pick = (key) => query.get(key) || hash.get(key) || '';
 
   return {
     accessToken: pick('accessToken') || pick('access_token'),
@@ -27,32 +32,38 @@ function readFromUrl() {
     expiresIn: Number(pick('expiresIn') || pick('expires_in') || 0),
     email: pick('email'),
     userId: pick('userId') || pick('user_id'),
-  }
+  };
 }
 
 onMounted(async () => {
   try {
-    const payload = readFromUrl()
+    const payload = readFromUrl();
     if (!payload.accessToken) {
-      status.value = t('auth.tokenNotFound')
-      setTimeout(() => router.replace('/'), 1200)
-      return
+      status.value = t('auth.tokenNotFound');
+      setTimeout(() => router.replace('/'), 1200);
+      return;
     }
 
-    authStore.setSession(payload)
-    const me = await authStore.loadMe().catch(() => null)
-    const hasNickname = !!(me?.nickname && String(me.nickname).trim())
-    const hasPersona = !!(me?.localPreference && String(me.localPreference).trim())
-    const onboardingDone = hasNickname && hasPersona
+    authStore.setSession(payload);
+    const me = await authStore.loadMe().catch(() => null);
+    const hasNickname = !!(me?.nickname && String(me.nickname).trim());
+    const hasPersona = !!(
+      me?.localPreference && String(me.localPreference).trim()
+    );
+    const onboardingDone = hasNickname && hasPersona;
     status.value = onboardingDone
       ? '로그인 완료! 홈으로 이동합니다.'
-      : '첫 로그인 확인! 닉네임과 페르소나를 설정해 주세요.'
-    setTimeout(() => router.replace(onboardingDone ? '/discover' : '/profile/setup'), 500)
+      : '첫 로그인 확인! 닉네임과 페르소나를 설정해 주세요.';
+    const savedRedirect = consumePostLoginRedirect();
+    const nextPath = onboardingDone
+      ? savedRedirect || resolvePostLoginRedirect(route)
+      : '/profile/setup';
+    setTimeout(() => router.replace(nextPath), 500);
   } catch {
-    status.value = t('auth.error')
-    setTimeout(() => router.replace('/'), 1200)
+    status.value = t('auth.error');
+    setTimeout(() => router.replace('/'), 1200);
   }
-})
+});
 </script>
 
 <template>
@@ -74,4 +85,3 @@ onMounted(async () => {
   font-weight: 700;
 }
 </style>
-

--- a/src/views/DiscoverView.vue
+++ b/src/views/DiscoverView.vue
@@ -26,6 +26,7 @@ import {
 import { getApiLangCode } from '@/i18n';
 import earthImage from '../../asset/earth.png';
 import airplaneImage from '../../asset/airplane.png';
+import { isAuthExpiredError } from '@/utils/authFlow';
 
 const { t, locale } = useI18n();
 const router = useRouter();
@@ -186,6 +187,10 @@ async function loadTourCourses() {
       authStore.accessToken || null,
     );
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     tourCourses.value = [];
     tourCoursesError.value = e?.message || String(e);
   } finally {
@@ -207,6 +212,10 @@ async function toggleSaveCourse(course) {
     const row = tourCourses.value.find((c) => c.id === cid);
     if (row) row.isSaved = saved;
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     window.alert?.(e?.message || t('discover.alert.saveFailed'));
   } finally {
     savingTourCourseId.value = null;
@@ -242,6 +251,10 @@ async function loadSavedPlansRemote() {
   try {
     savedPlansRemote.value = await fetchSavedPlans(authStore.accessToken);
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     savedPlansRemote.value = [];
     savedPlansError.value = e?.message || String(e);
   } finally {

--- a/src/views/EventDetailView.vue
+++ b/src/views/EventDetailView.vue
@@ -20,6 +20,7 @@ import {
 import { fetchEventById } from '@/services/eventService'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { useServerSavedEventsStore } from '@/stores/useServerSavedEventsStore'
+import { isAuthExpiredError } from '@/utils/authFlow'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -66,6 +67,10 @@ watch(
         isLiked.value = serverEvents.isSaved(sid)
       }
     } catch (e) {
+      if (isAuthExpiredError(e)) {
+        await authStore.handleAuthExpired(router, route)
+        return
+      }
       error.value = e.message || t('event.loadError')
     } finally {
       loading.value = false
@@ -80,8 +85,15 @@ watch(
     const sid = resolvedId.value != null ? String(resolvedId.value).trim() : ''
     if (!sid || !eventDetail.value) return
     if (token) {
-      await serverEvents.refresh(token)
-      isLiked.value = serverEvents.isSaved(sid)
+      try {
+        await serverEvents.refresh(token)
+        isLiked.value = serverEvents.isSaved(sid)
+      } catch (e) {
+        if (isAuthExpiredError(e)) {
+          await authStore.handleAuthExpired(router, route)
+          return
+        }
+      }
     } else {
       isLiked.value = false
     }
@@ -184,6 +196,10 @@ async function toggleLike() {
     const saved = await serverEvents.toggle(sid, authStore.accessToken)
     isLiked.value = saved
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+        await authStore.handleAuthExpired(router, route)
+        return
+    }
     window.alert?.(e?.message || '행사 저장 처리에 실패했습니다.')
   } finally {
     likeSaving.value = false

--- a/src/views/LandingView.vue
+++ b/src/views/LandingView.vue
@@ -1,13 +1,20 @@
 <script setup>
 import { ref, computed } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { getGoogleLoginUrl } from '@/services/authService';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { SUPPORTED_LOCALES, setLocale, getCurrentLocale } from '@/i18n';
+import {
+  AUTH_EXPIRED_REASON,
+  AUTH_EXPIRED_MESSAGE,
+  resolvePostLoginRedirect,
+  storePostLoginRedirect,
+} from '@/utils/authFlow';
 
 const { t } = useI18n();
 const router = useRouter();
+const route = useRoute();
 const authStore = useAuthStore();
 const authMode = ref('login');
 const showLangDrop = ref(false);
@@ -15,6 +22,10 @@ const email = ref('');
 const password = ref('');
 const confirmPassword = ref('');
 const loginError = ref('');
+
+if (route.query.reason === AUTH_EXPIRED_REASON) {
+  loginError.value = AUTH_EXPIRED_MESSAGE;
+}
 
 const currentLangLabel = computed(
   () =>
@@ -29,6 +40,8 @@ function selectLang(lang) {
 }
 
 function go() {
+  const redirectPath = resolvePostLoginRedirect(route);
+  storePostLoginRedirect(redirectPath);
   window.location.href = getGoogleLoginUrl();
 }
 
@@ -55,7 +68,8 @@ async function loginWithEmail() {
       await authStore.login(email.value.trim(), password.value);
     }
     await authStore.loadMe().catch(() => null);
-    router.push('/discover');
+    const nextPath = resolvePostLoginRedirect(route);
+    router.push(nextPath);
   } catch (e) {
     loginError.value = e.message || t('landing.validation.authFailed');
   }
@@ -313,7 +327,7 @@ async function loginWithEmail() {
             </button>
           </div>
 
-          <div class="landing__email-box">
+          <form class="landing__email-box" @submit.prevent="loginWithEmail">
             <input
               v-model="email"
               class="landing__input"
@@ -340,7 +354,7 @@ async function loginWithEmail() {
             />
             <button
               class="landing__btn landing__btn--email"
-              @click="loginWithEmail"
+              type="submit"
               :disabled="authStore.isLoading"
             >
               {{
@@ -354,7 +368,7 @@ async function loginWithEmail() {
               }}
             </button>
             <p v-if="loginError" class="landing__error">{{ loginError }}</p>
-          </div>
+          </form>
         </div>
       </div>
       <!-- /landing__bottom -->

--- a/src/views/ProfileSetupView.vue
+++ b/src/views/ProfileSetupView.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { personaOptions } from '@/components/ai/input-sheet/aiInputFlowConstants'
+import { isAuthExpiredError } from '@/utils/authFlow'
 
 const authStore = useAuthStore()
 const router = useRouter()
+const route = useRoute()
 const nickname = ref((authStore.user?.nickname || '').trim())
 const selectedPersona = ref(authStore.user?.localPreference || 'balanced')
 const selectedLanguage = ref(authStore.user?.preferredLanguage || '한국어')
@@ -32,6 +34,10 @@ async function submit() {
     })
     router.replace('/discover')
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     error.value = e?.message || '닉네임 저장에 실패했습니다.'
   } finally {
     saving.value = false

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { Bell, Globe, Settings, UserRound } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { personaOptions } from '@/components/ai/input-sheet/aiInputFlowConstants'
 import { setLocale } from '@/i18n'
+import { isAuthExpiredError } from '@/utils/authFlow'
 
 const LABEL_TO_LOCALE = {
   '한국어': 'ko',
@@ -17,6 +18,7 @@ const LABEL_TO_LOCALE = {
 const { t } = useI18n()
 const authStore = useAuthStore()
 const router = useRouter()
+const route = useRoute()
 
 const ALARM_KEY = 'bts:settings:alarm'
 const languageOptions = ['한국어', 'English', '日本語', '中文']
@@ -41,14 +43,16 @@ const currentPersonaLabel = computed(() => {
   return persona ? t(persona.labelKey) : t('ai.persona.balanced')
 })
 
-onMounted(() => {
-  authStore
-    .loadMe()
-    .then(() => {
-      language.value = authStore.user?.preferredLanguage || '한국어'
-      selectedPersona.value = authStore.user?.localPreference || 'balanced'
-    })
-    .catch(() => null)
+onMounted(async () => {
+  try {
+    await authStore.loadMe()
+    language.value = authStore.user?.preferredLanguage || '한국어'
+    selectedPersona.value = authStore.user?.localPreference || 'balanced'
+  } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+    }
+  }
 })
 
 function openModal(type) {
@@ -72,8 +76,11 @@ async function saveLanguage(next) {
     language.value = next
     setLocale(LABEL_TO_LOCALE[next] ?? 'ko')
     closeModal()
-  } catch {
-    /* ignore */
+  } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
   }
 }
 
@@ -91,6 +98,10 @@ async function savePersona() {
     await authStore.saveProfile({ localPreference: selectedPersona.value })
     personaMessage.value = t('profile.personaSaved')
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     personaMessage.value = e?.message || t('profile.personaSaveFailed')
   } finally {
     personaSaving.value = false

--- a/src/views/ResultView.vue
+++ b/src/views/ResultView.vue
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/stores/useAuthStore'
 import MapView from '@/components/map/MapView.vue'
 import ItineraryTimeline from '@/components/itinerary/ItineraryTimeline.vue'
 import { fetchSavedPlanDetail, saveStructuredPlan } from '@/services/savedPlansService'
+import { isAuthExpiredError } from '@/utils/authFlow'
 import {
   flattenStructuredSlots,
   buildMapMarkersFromStructured,
@@ -105,6 +106,10 @@ async function loadPlanFromRoute() {
     })
     selectedDay.value = 1
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     planLoadError.value = e.message || '일정을 불러오지 못했습니다.'
   } finally {
     loadingPlan.value = false
@@ -162,6 +167,10 @@ async function saveCourse() {
     await router.replace({ name: 'result', query: { planId: String(summary.id) } })
     window.alert?.('일정을 저장했어요. 디스커버 「내가 만든 일정」·저장함에서 볼 수 있어요.')
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     window.alert?.(e.message || '저장에 실패했습니다.')
   } finally {
     savingCourse.value = false

--- a/src/views/SavedView.vue
+++ b/src/views/SavedView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref, watch, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { CalendarDays, Heart, MapPin, Sparkles } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/useAuthStore'
@@ -9,12 +9,14 @@ import { useServerSavedEventsStore } from '@/stores/useServerSavedEventsStore'
 import { fetchSavedPlans } from '@/services/savedPlansService'
 import { fetchSavedTourCourses } from '@/services/tourCourseService'
 import { getApiLangCode } from '@/i18n'
+import { isAuthExpiredError } from '@/utils/authFlow'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
 const serverAttractions = useServerSavedAttractionsStore()
 const serverEvents = useServerSavedEventsStore()
 const router = useRouter()
+const route = useRoute()
 
 /** 서버 저장 AI 일정 */
 const activeTab = ref('plan')
@@ -53,6 +55,10 @@ async function loadSavedTourCourses() {
   try {
     savedTourCourses.value = await fetchSavedTourCourses(getApiLangCode(), authStore.accessToken)
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     savedTourCourses.value = []
     savedTourCoursesError.value = e?.message || String(e)
   } finally {
@@ -81,6 +87,10 @@ async function loadSavedPlansRemote() {
   try {
     savedPlansRemote.value = await fetchSavedPlans(authStore.accessToken)
   } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
     savedPlansRemote.value = []
     savedPlansError.value = e?.message || String(e)
   } finally {
@@ -88,32 +98,54 @@ async function loadSavedPlansRemote() {
   }
 }
 
+async function refreshSavedAttractions() {
+  try {
+    await serverAttractions.refresh(authStore.accessToken)
+  } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
+  }
+}
+
+async function refreshSavedEvents() {
+  try {
+    await serverEvents.refresh(authStore.accessToken)
+  } catch (e) {
+    if (isAuthExpiredError(e)) {
+      await authStore.handleAuthExpired(router, route)
+      return
+    }
+  }
+}
+
 watch(
   () => authStore.accessToken,
   () => {
     void loadSavedPlansRemote()
-    void serverAttractions.refresh(authStore.accessToken)
-    void serverEvents.refresh(authStore.accessToken)
+    void refreshSavedAttractions()
+    void refreshSavedEvents()
     void loadSavedTourCourses()
   },
 )
 
 watch(activeTab, (tab) => {
   if (tab === 'place' && authStore.accessToken) {
-    void serverAttractions.refresh(authStore.accessToken)
+    void refreshSavedAttractions()
   }
   if (tab === 'home_course' && authStore.accessToken) {
     void loadSavedTourCourses()
   }
   if (tab === 'event' && authStore.accessToken) {
-    void serverEvents.refresh(authStore.accessToken)
+    void refreshSavedEvents()
   }
 })
 
 onMounted(() => {
   void loadSavedPlansRemote()
-  void serverAttractions.refresh(authStore.accessToken)
-  void serverEvents.refresh(authStore.accessToken)
+  void refreshSavedAttractions()
+  void refreshSavedEvents()
   void loadSavedTourCourses()
 })
 


### PR DESCRIPTION
## 개요
401 응답 발생 시 세션 만료를 공통 처리하고, 로그인 후 원래 페이지로 복귀할 수 있도록 인증 흐름을 개선했습니다.

## 작업 내용
- 보호 페이지 진입 시 로그인 여부 확인 및 redirect 처리
- 401 응답 공통 처리 추가
- 로그인 만료 시 로그인 화면 이동 및 안내 문구 표시
- 재로그인 후 원래 페이지 복귀 처리
- 구글 로그인 redirect 복귀 처리
- 로그인/회원가입 Enter 제출 동작 추가

## 관련 이슈
- #55 
